### PR TITLE
Replace System.Drawing.Color

### DIFF
--- a/Sanchez.Test/Extensions/ColorExtensionsTests.cs
+++ b/Sanchez.Test/Extensions/ColorExtensionsTests.cs
@@ -1,6 +1,8 @@
 ﻿using FluentAssertions;
 using NUnit.Framework;
 using Sanchez.Extensions;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 
 namespace Sanchez.Test.Extensions
 {
@@ -12,12 +14,13 @@ namespace Sanchez.Test.Extensions
         [TestCase("#aabbcc")]
         public void TripletConversion(string triplet)
         {
-            var colour = triplet.FromHexTriplet();
+            Color? colour = triplet.FromHexTriplet();
             Assert.NotNull(colour);
+            Rgb24 rgb = colour.Value.ToPixel<Rgb24>();
 
-            colour.Value.R.Should().Be(170);
-            colour.Value.G.Should().Be(187);
-            colour.Value.B.Should().Be(204);
+            rgb.R.Should().Be(170);
+            rgb.G.Should().Be(187);
+            rgb.B.Should().Be(204);
         }
 
         [Test]

--- a/Sanchez.Test/Extensions/TintExtensionsTests.cs
+++ b/Sanchez.Test/Extensions/TintExtensionsTests.cs
@@ -1,7 +1,7 @@
-﻿using System.Drawing;
-using FluentAssertions;
+﻿using FluentAssertions;
 using NUnit.Framework;
 using Sanchez.Extensions;
+using SixLabors.ImageSharp;
 
 namespace Sanchez.Test.Extensions
 {
@@ -11,7 +11,7 @@ namespace Sanchez.Test.Extensions
         [Test]
         public void TintMatrixTest()
         {
-            var colour = Color.FromArgb(128, 255, 15);
+            Color colour = Color.FromRgb(128, 255, 15);
             var tintMatrix = TintExtensions.CreateTintMatrix(colour);
 
             tintMatrix.M11.Should().Be(128f / 255);

--- a/Sanchez/Extensions/ColorExtensions.cs
+++ b/Sanchez/Extensions/ColorExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Drawing;
+﻿using SixLabors.ImageSharp;
 
 namespace Sanchez.Extensions
 {
@@ -13,14 +12,12 @@ namespace Sanchez.Extensions
         /// <returns>colour, or <c>null</c> if unable to parse</returns>
         public static Color? FromHexTriplet(this string triplet)
         {
-            try
+            if (Color.TryParseHex(triplet, out Color result))
             {
-                return ColorTranslator.FromHtml(triplet.PadLeft(7, '#'));
+                return result;
             }
-            catch (Exception)
-            {
-                return null;
-            }
+
+            return null;
         }
     }
 }

--- a/Sanchez/Extensions/ImageExtensions.cs
+++ b/Sanchez/Extensions/ImageExtensions.cs
@@ -2,7 +2,6 @@
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
 using SixLabors.ImageSharp.Processing.Processors.Normalization;
-using Color = System.Drawing.Color;
 
 namespace Sanchez.Extensions
 {

--- a/Sanchez/Extensions/TintExtensions.cs
+++ b/Sanchez/Extensions/TintExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
-using Color = System.Drawing.Color;
 
 namespace Sanchez.Extensions
 {
@@ -21,14 +21,14 @@ namespace Sanchez.Extensions
         /// <param name="colour">colour to tint by</param>
         public static ColorMatrix CreateTintMatrix(Color colour)
         {
-            static float ToMatrixValue(byte value) => (float) value / 255;
+            var colourVector = colour.ToPixel<Rgba32>().ToScaledVector4();
 
             // Create a identity matrix with R-R', G-G' and B-B' scaled by the tint colour
             var tintMatrix = new ColorMatrix
             {
-                M11 = ToMatrixValue(colour.R),
-                M22 = ToMatrixValue(colour.G),
-                M33 = ToMatrixValue(colour.B),
+                M11 = colourVector.X,
+                M22 = colourVector.Y,
+                M33 = colourVector.Z,
                 M44 = 1
             };
 

--- a/Sanchez/Models/RenderOptions.cs
+++ b/Sanchez/Models/RenderOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Drawing;
+﻿using SixLabors.ImageSharp;
 
 namespace Sanchez.Models
 {


### PR DESCRIPTION
Replaces the `System.Drawing.Color` usage with ImageSharp's generic pixel type agnostic [`Color`](https://docs.sixlabors.com/api/ImageSharp/SixLabors.ImageSharp.Color.html) struct. 

Incidentally the ImageSharp `Color.TryParseHex(string hex)` can handle `#xxx`, `#xxxxxx`, and `#xxxxxxxx` hex formats with or without the leading `#`.

P.S Very cool project btw 👍 