### PR TITLE
Use more luminance levels and dispose of images

### DIFF
--- a/Sanchez/Extensions/ImageExtensions.cs
+++ b/Sanchez/Extensions/ImageExtensions.cs
@@ -17,11 +17,12 @@ namespace Sanchez.Extensions
         internal static void TintAndBlend(this Image image, Color tint)
         {
             // IR satellite image with equalised histogram in order to enhance cloud contrast
-            var originalImage = image.Clone(context =>
+            using var originalImage = image.Clone(context =>
             {
                 context.HistogramEqualization(new HistogramEqualizationOptions
                 {
-                    Method = HistogramEqualizationMethod.Global
+                    Method = HistogramEqualizationMethod.Global,
+                    LuminanceLevels = 65536
                 });
             });
 

--- a/Sanchez/Models/ImageStack.cs
+++ b/Sanchez/Models/ImageStack.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using SixLabors.ImageSharp;
 
@@ -7,13 +8,43 @@ namespace Sanchez.Models
     /// <summary>
     ///     All images used in a composition.
     /// </summary>
-    public class ImageStack
+    public class ImageStack : IDisposable
     {
+        private bool isDisposed;
+
         public Image? Underlay { get; set; }
         public Image? Satellite { get; set; }
         public Image? Mask { get; set; }
         public Image? Overlay { get; set; }
 
-        public IEnumerable<Image> All => new[] { Underlay, Satellite, Mask, Overlay }.Where(image => image != null)!;
+        public IEnumerable<Image> All
+            => new[] { Underlay, Satellite, Mask, Overlay }
+            .Where(image => image != null)!;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!isDisposed)
+            {
+                if (disposing)
+                {
+                    this.Underlay?.Dispose();
+                    this.Satellite?.Dispose();
+                    this.Mask?.Dispose();
+                    this.Overlay?.Dispose();
+                }
+
+                this.Underlay = null;
+                this.Satellite = null;
+                this.Mask = null;
+                this.Overlay = null;
+                isDisposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
     }
 }

--- a/Sanchez/Services/Compositor.cs
+++ b/Sanchez/Services/Compositor.cs
@@ -81,11 +81,11 @@ namespace Sanchez.Services
             {
                 var threadCount = options.Threads ?? Environment.ProcessorCount;
                 Log.Information("Compositing batch with {threadCount} threads", threadCount);
-                
+
                 Parallel.ForEach(sourceFiles, new ParallelOptions
-                    {
-                        MaxDegreeOfParallelism = threadCount
-                    },
+                {
+                    MaxDegreeOfParallelism = threadCount
+                },
                     file =>
                     {
                         // Handle ctrl+c requests
@@ -165,7 +165,7 @@ namespace Sanchez.Services
             }
 
             // Load all images
-            var stack = new ImageStack
+            using var stack = new ImageStack
             {
                 Underlay = Image.Load(options.UnderlayPath),
                 Satellite = Image.Load(sourcePath),


### PR DESCRIPTION
Fixes #19 and #20 

This isn't fully tested (_I couldn't find an easy way to test the output to see if banding was removed_) but should fix both issues. 

When you use Histogram equalization the default luminance levels are set to 256 which works for an 8 bit grayscale input. Bumping them up should help.

Let me know if this doesn't help with #20 and I'll have another look once I understand the system better and can view the output. 