### PR TITLE
Improve JPG export quality

### DIFF
--- a/Sanchez.Processing/Extensions/Images/ImageExtensions.cs
+++ b/Sanchez.Processing/Extensions/Images/ImageExtensions.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using ExifLibrary;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats.Jpeg;
 using SixLabors.ImageSharp.PixelFormats;
 
 namespace Sanchez.Processing.Extensions.Images;
@@ -21,13 +22,20 @@ public static class ImageExtensions
         }
 
         // Save image
-        try
+        if (String.Equals(Path.GetExtension(path), ".jpg", StringComparison.OrdinalIgnoreCase))
         {
-            await image.SaveAsync(path, cancellationToken: ct);
+            await image.SaveAsJpegAsync(path, new JpegEncoder { Quality = 95 }, ct);
         }
-        catch (NotSupportedException)
+        else
         {
-            throw new ValidationException($"Unsupported output file extension: {Path.GetExtension(path)}");
+            try
+            {
+                await image.SaveAsync(path, cancellationToken: ct);
+            }
+            catch (NotSupportedException)
+            {
+                throw new ValidationException($"Unsupported output file extension: {Path.GetExtension(path)}");
+            }
         }
 
         // Add EXIF metadata to image


### PR DESCRIPTION
Full disclosure: I am not a C# developer - I must need glasses. This pull is a proof of concept that I'm not necessarily expecting to get merged since a more complete implementation is probably better.

When Sanchez exports to a jpg, it uses ImageSharp's default quality for jpg, which is only 75%. This results in artifacts in the final image. I propose increasing the default jpeg quality to 90 or 95%. The difference is drastic (or maybe I really can see sharp):

![Difference](https://user-images.githubusercontent.com/24253715/186557152-7dbdc8fd-5f81-40ab-a90a-82876c83d179.png)

This pull request checks if the output file is a jpg, and if it is, it calls `SaveAsJpegAsync` and sets the quality to 95%. If it's not saving to a jpeg, it uses the same code as before.

In a complete implementation, the following probably needs done:

1. Set the default value to 90% or 95% (or keep it the same, if the following items are done)
2. Add a command line flag to let users pick their own jpeg quality
3. Make the underlay cache honor the same quality setting

I'd do a full implementation myself, but mine would probably be kludgier than someone else's - and I'm happy with having it hardcoded at 95% 😄 

