### PR TITLE
Update Satellites.json

### DIFF
--- a/Sanchez/Resources/Satellites.json
+++ b/Sanchez/Resources/Satellites.json
@@ -36,6 +36,20 @@
     ]
   },
   {
+    "DisplayName": "Himawari-9",
+    "FilenamePrefix": "^Himawari9_FD_IR_",
+    "FilenameParser": "Goesproc",
+    "Longitude": 140.7,
+    "LongitudeAdjustment": -0.8,
+    "Brightness": 1,
+    "Crop": [
+      0.007273,
+      0.007272,
+      0.007273,
+      0.007272
+    ]
+  },
+  {
     "DisplayName": "GEO-KOMPSAT-2A",
     "FilenamePrefix": "^IMG_FD_.*",
     "FilenameParser": "Xrit",

--- a/Sanchez/Resources/Satellites.json
+++ b/Sanchez/Resources/Satellites.json
@@ -18,7 +18,7 @@
     "DisplayName": "GOES-18",
     "FilenamePrefix": "GOES18_FD_CH13_(?!enhanced)",
     "FilenameParser": "Goesproc",
-    "Longitude": -137.2,
+    "Longitude": -137.0,
     "Brightness": 0.95
   },
   {


### PR DESCRIPTION
Unlike was originally planned, GOES-18 will be remaining at 137.0 W: [https://www.ospo.noaa.gov/data/messages/2023/01/MSG_20230104_1805.html](https://www.ospo.noaa.gov/data/messages/2023/01/MSG_20230104_1805.html).

Additionally, add Himawari-9 to Satellites.json